### PR TITLE
Disable verify page

### DIFF
--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -1,11 +1,5 @@
-import { Suspense } from 'react';
-
-import Verify from '@/app/ui/verify';
-
 export default function Page() {
   return (
-    <Suspense fallback={<div>Yükleniyor...</div>}>
-      <Verify />
-    </Suspense>
+    <span className="text-red-500">Bu sayfa devre dışı, hesabını doğrulamak için Discord'u takip et.</span>
   );
 }


### PR DESCRIPTION
adminlerin henüz crew rolü vermeden verify yapılabilinmesini sağlıyordu
discord rolüne bakılıp ona göre sayfayı kullanılabileceğine karar verilebilirdi de üşendiğim için kaldırıyorum şimdilik